### PR TITLE
Fix data displaying bug in 10k rows table

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -413,6 +413,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
     }
 
     this.temp = temp;
+    this.cd.detectChanges();
   }
 
   /**


### PR DESCRIPTION
When long scroll is done in virtual scroll demo (10k rows) table data blinks and disappears. Steps to reproduce:

- Open 10k rows table sample;
- Put cursor on scroll bar's slider, then press and hold mouse left key; 
- Quickly move slider to distance large enough to fully update cells in table (to the middle of the scroll bar, for example);
- Keeping mouse standing, release the left key.
- Result - empty table, after scrolling via mouse wheel, for example, data appears again.

Bug was reproduced in Chrome/FF/IE11. In the original source code firstly appeared in version 13.0.1.
